### PR TITLE
Allow options to be passed in a request object to elasticsearchclient.

### DIFF
--- a/lib/SearchQueue.js
+++ b/lib/SearchQueue.js
@@ -19,7 +19,7 @@ SearchQueue.prototype = {
       if( this._assertValidSearch(snap.name(), snap.val()) ) {
          this.esc.search(dat.index, dat.type, {
             "query": dat.query
-         })
+         }, dat.options)
             .on('data', function(data) {
                console.log('search result', data);
                this._reply(snap.name(), JSON.parse(data));


### PR DESCRIPTION
Including this feature allows URL parameters like `search_type` to be passed to elasticsearch. If no options are passed in the request, elasticsearchclient is smart enough not to choke on a value of `undefined`.
