### PR TITLE
Add priority to the data object received from Firebase in PathMonitor

### DIFF
--- a/lib/PathMonitor.js
+++ b/lib/PathMonitor.js
@@ -24,6 +24,7 @@ PathMonitor.prototype = {
 
    _process: function(fn, snap) {
       var dat = snap.val();
+      dat['.priority'] = snap.getPriority();
       if( this.filter(dat) ) {
          fn.call(this, snap.name(), this.parse(dat));
       }


### PR DESCRIPTION
This way, priority can (1) be used in filter and parse functions in config.js and (2) be indexed by ES. This might not be the best design since, if to be completely consistent with firebase, exportVal() should be used instead of val(), but that would break other parts of the codebase expecting data to contain the actual reference data. Thoughts?
