### PR TITLE
Fixing 2 inaccuracies in config documentation. (1) The parse function is...

### DIFF
--- a/config.js
+++ b/config.js
@@ -53,7 +53,7 @@ else {
  * {string}   type:    [required] name of the ES object type this document will be stored as
  * {Array}    fields:  list of fields to be monitored (defaults to all fields)
  * {Function} filter:  if provided, only records that return true are indexed
- * {Function} parser:  if provided, the results of this function are passed to ES, rather than the raw data (fields is ignored if this is used)
+ * {Function} parse:  if provided, the results of this function are passed to ES, rather than the raw data
  ****************************************************/
 
 exports.paths = [


### PR DESCRIPTION
... called `parse`, not `parser` (2) `parse`, as the code is currently written, on the master branch, is called regardless of the values of `fields`
