### PR TITLE
Parse stringified JSON query

### DIFF
--- a/lib/SearchQueue.js
+++ b/lib/SearchQueue.js
@@ -18,7 +18,7 @@ SearchQueue.prototype = {
       var dat = snap.val();
       if( this._assertValidSearch(snap.name(), snap.val()) ) {
          this.esc.search(dat.index, dat.type, {
-            "query": dat.query
+            "query": (typeof(dat.query)=='string' ? JSON.parse(dat.query) : dat.query)
          }, dat.options)
             .on('data', function(data) {
                console.log('search result', data);


### PR DESCRIPTION
When trying to run ElasticSearch queries on nested fields, Firebase breaks the query (because the "." isn't allowed as a Firebase key). The can be avoided if the query data is stringified before pushing to Firebase.
