### PR TITLE
Allow for complex search JSON, including sort

### DIFF
--- a/lib/SearchQueue.js
+++ b/lib/SearchQueue.js
@@ -17,9 +17,10 @@ SearchQueue.prototype = {
    _process: function(snap) {
       var dat = snap.val();
       if( this._assertValidSearch(snap.name(), snap.val()) ) {
-         this.esc.search(dat.index, dat.type, {
-            "query": (typeof(dat.query)=='string' ? JSON.parse(dat.query) : dat.query)
-         }, dat.options)
+         // structure jquery into JSON object format expected by elasticsearch
+         var queryObj = typeof(dat.query)=='string' ? JSON.parse(dat.query) : dat.query;
+         queryObj = queryObj.hasOwnProperty('query') ? queryObj : { "query": queryObj };
+         this.esc.search(dat.index, dat.type, queryObj, dat.options)
             .on('data', function(data) {
                console.log('search result', data);
                this._reply(snap.name(), JSON.parse(data));


### PR DESCRIPTION
Elasticsearch allows for sorting and a few other advanced search features, but they require the JSON request to be formatted with top-level keys other than just "query". Previously, Flashlight limited the JSON post to only the "query" key. The proposed change near line 22 would allow for a more complex query to be submitted.

If the JSON object contains a top-level key named "query", then the JSON will be passed as-is. If it does not contain the "query" key, it will automatically be added (keeping this change reverse-compatible).

Example 1 (same as previous behavior): 

```
{ "term": { "user": "kimchy" } } 
```

would be converted to:

```
{ "query": { "term": { "user": "kimchy" } } }
```

Example 2 (additional new behavior):

```
{ "query": { "term": { "user": "kimchy" } }, "sort": [{ "name": { "order": "desc" } }] }
```

would be submitted as-is because it already contains the top-level "query" key.
