### PR TITLE
Fix _isJSON in SearchQueue

### DIFF
--- a/lib/SearchQueue.js
+++ b/lib/SearchQueue.js
@@ -89,7 +89,7 @@ SearchQueue.prototype = {
       setTimeout(this._housekeeping.bind(this), this.cleanupInterval);
    },
 
-   _isJson: function() {
+   _isJson: function(str) {
        try {
            JSON.parse(str);
        } catch (e) {


### PR DESCRIPTION
JSON parsing for all requests was broken due to variable not being passed in function definition.