### PR TITLE
Adding start script in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "node": "0.10.x"
   },
   "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
   "devDependencies": {},
   "dependencies": {
     "elastic.js": "~1.1.1",


### PR DESCRIPTION
For heroku deployment this is required to work as expected and specified in README.