### PR TITLE
Include firebase-admin and generated credentials

### DIFF
--- a/lib/fbutil.js
+++ b/lib/fbutil.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var Firebase = require('firebase');
+var admin = require('firebase-admin');
 require('colors');
 
 exports.init = function(databaseURL, serviceAccount) {
    var config = {
      databaseURL: databaseURL,
-     serviceAccount: serviceAccount
+     credential: admin.credential.cert(serviceAccount)
    };
-   Firebase.initializeApp(config)
+   admin.initializeApp(config)
 };
 
 exports.fbRef = function(path) {
-   return Firebase.database().ref().child(path);
+   return admin.database().ref().child(path);
 };
 
 exports.pathName = function(ref) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "JQDeferred": "~1.9.1",
     "colors": "~0.6.2",
     "elasticsearch": "^11.0.1",
-    "firebase": "^3.5.2"
+    "firebase-admin": "^4.0.4"
   }
 }


### PR DESCRIPTION
Fixed the warning about not using firebase-admin and changed the serviceAccount to a credential generated with firebase-admin. 

This changeset deals with the issue #97 