### PR TITLE
Return whole ES response

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,44 @@ After you've deployed to Heroku, you need to create your initial index name to p
 
  - `curl -X POST <BONSAI_URL>/firebase` (ex: https://user:pass@yourbonsai.bonsai.io/firebase)
  
+Migration
+=========
+
+January 1st, 2017
+-----------------
+
+Flashlight now returns the direct output of ElasticSearch, instead of just returning the _hits_ part. This change is required to support _aggregations_ and include richer information. You must change how you read the reponse accordingly. You can see example responses of Flashlight below:
+### Before
+```
+"total" : 1000,
+"max_score" : null,
+"hits" : [
+  ..
+]
+```
+### After
+```
+{
+  "took" : 63,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 5,
+    "successful" : 5,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : 1000,
+    "max_score" : null,
+    "hits" : [
+      ..
+    ]
+  },
+  "aggregations" : {
+    ..
+  }
+}
+```
+
 Advanced Topics
 ===============
  

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ After you've deployed to Heroku, you need to create your initial index name to p
 Migration
 =========
 
-January 1st, 2017
+0.2.0 -> 0.3.0
 -----------------
 
 Flashlight now returns the direct output of ElasticSearch, instead of just returning the _hits_ part. This change is required to support _aggregations_ and include richer information. You must change how you read the reponse accordingly. You can see example responses of Flashlight below:
-### Before
+
+### Before, in 0.2.0
 ```
 "total" : 1000,
 "max_score" : null,
@@ -72,7 +73,7 @@ Flashlight now returns the direct output of ElasticSearch, instead of just retur
   ..
 ]
 ```
-### After
+### After, in 0.3.0
 ```
 {
   "took" : 63,

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Read `example/index.html` and `example/example.js` for a client implementation. 
  - Push an object to `/search/request` which has the following keys: `index`, `type`, and `q` (or `body` for advanced queries)
  - Listen on `/search/response` for the reply from the server
 
-The `body` object can be any valid ElasticSearch DSL structure (see More on Queries).
+The `body` object can be any valid ElasticSearch DSL structure (see [Building ElasticSearch Queries](https://github.com/firebase/flashlight#building-elasticsearch-queries)).
 
 Deploy to Heroku
 ================

--- a/example/example.js
+++ b/example/example.js
@@ -109,19 +109,19 @@
 
     // the rest of this just displays data in our demo and probably
     // isn't very interesting
-    var totalText = dat.total;
-    if( dat.hits && dat.hits.length !== dat.total ) {
-      totalText = dat.hits.length + ' of ' + dat.total;
+    var totalText = dat.hits.total;
+    if( dat.hits.hits && dat.hits.hits.length !== dat.hits.total ) {
+      totalText = dat.hits.hits.length + ' of ' + dat.hits.total;
     }
     $('#total').text('(' + totalText + ')');
 
     var $pair = $('#results')
       .text(JSON.stringify(dat, null, 2))
       .removeClass('error zero');
-    if( dat.error ) {
+    if( dat.hits.error ) {
       $pair.addClass('error');
     }
-    else if( dat.total < 1 ) {
+    else if( dat.hits.total < 1 ) {
       $pair.addClass('zero');
     }
   }

--- a/example/example.js
+++ b/example/example.js
@@ -99,8 +99,8 @@
 
   // when results are written to the database, read them and display
   function showResults(snap) {
-    var dat = snap.val();
-    if( dat === null ) { return; } // wait until we get data
+    if( !snap.exists() ) { return; } // wait until we get data
+    var dat = snap.val().hits;
 
     // when a value arrives from the database, stop listening
     // and remove the temporary data from the database
@@ -109,19 +109,19 @@
 
     // the rest of this just displays data in our demo and probably
     // isn't very interesting
-    var totalText = dat.hits.total;
-    if( dat.hits.hits && dat.hits.hits.length !== dat.hits.total ) {
-      totalText = dat.hits.hits.length + ' of ' + dat.hits.total;
+    var totalText = dat.total;
+    if( dat.hits && dat.hits.length !== dat.total ) {
+      totalText = dat.hits.length + ' of ' + dat.total;
     }
     $('#total').text('(' + totalText + ')');
 
     var $pair = $('#results')
       .text(JSON.stringify(dat, null, 2))
       .removeClass('error zero');
-    if( dat.hits.error ) {
+    if( dat.error ) {
       $pair.addClass('error');
     }
-    else if( dat.hits.total < 1 ) {
+    else if( dat.total < 1 ) {
       $pair.addClass('zero');
     }
   }

--- a/lib/SearchQueue.js
+++ b/lib/SearchQueue.js
@@ -38,7 +38,7 @@ SearchQueue.prototype = {
       }
       else {
          console.log('query result %s: %d hits'.yellow, key, results.hits.total);
-         this._send(key, results.hits);
+         this._send(key, results);
       }
    },
 


### PR DESCRIPTION
Return not only 'hits' of the ES response, return the whole response.

Flashlight returns only 'hits' part of the Elastic Search response. This causes it to ignore other parts of the response such as aggregation results.

For example 10 is the result of current master code, 11 is the result after this change.
![untitled](https://cloud.githubusercontent.com/assets/1329010/21468503/b5a28fc6-ca1c-11e6-862e-8db2152bbbd0.png)
