### PR TITLE
Remove unused parameter matchWholeWords

### DIFF
--- a/lib/SearchQueue.js
+++ b/lib/SearchQueue.js
@@ -144,6 +144,6 @@ SearchQueue.prototype = {
    }
 };
 
-exports.init = function(esc, reqPath, resPath, matchWholeWords, cleanupInterval) {
-   new SearchQueue(esc, fbutil.fbRef(reqPath), fbutil.fbRef(resPath), matchWholeWords, cleanupInterval);
+exports.init = function(esc, reqPath, resPath, cleanupInterval) {
+   new SearchQueue(esc, fbutil.fbRef(reqPath), fbutil.fbRef(resPath), cleanupInterval);
 };


### PR DESCRIPTION
The SearchQueue module exports function signtuare was including a parameter that is unused, which meant that the cleanupInterval variable in the repo was being passed around incorrectly.  This PR removes that parameter.