### PR TITLE
The "return null;" statement should be inside if block

### DIFF
--- a/lib/SearchQueue.js
+++ b/lib/SearchQueue.js
@@ -97,8 +97,8 @@ SearchQueue.prototype = {
        queryData.body = this._getJSON(queryData.body);
        if( queryData.body === null ) {
          this._replyError(key, 'Search body was a string but did not contain a valid JSON object. It must be an object or a JSON parsable string.');
+         return null;
        }
-       return null;
      }
 
      var query = {};


### PR DESCRIPTION
The "return null;" statement should be inside if block as the queryData still holds the query. 
Returning null outside if results in no response to queries which are supplied as string in queryData.body. I have tested the fix and it works like a charm.
Sample JSON for which the current version not working
{
"body":"{"query":{"filtered":{"query":{"match":{"subcategory":"Hair Cream"}},"filter":{"query":{"match":"availability.defaultwh":"true"}}}}}}"
"index":"firebase"
"type":"item"
}