### PR TITLE
Secured undefined path for existing refBuilders.

### DIFF
--- a/lib/fbutil.js
+++ b/lib/fbutil.js
@@ -16,6 +16,7 @@ exports.fbRef = function(path) {
 };
 
 exports.pathName = function(ref) {
+   if(typeof ref.parent === 'undefined') return ref.path;
    var p = ref.parent.key;
    return (p? p+'/' : '')+ref.key;
 };


### PR DESCRIPTION
For any usage of refBuilder, ref.parent is undefined. This causes the method to break and not index records at all.