### PR TITLE
Fix arguments to `PathMonitor.process` method on initFlashlight

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,6 @@ var timeoutObj = setInterval(function() {
 function initFlashlight() {
   console.log('Connecting to Firebase %s'.grey, conf.FB_URL);
   fbutil.init(conf.FB_URL, conf.FB_SERVICEACCOUNT);
-  PathMonitor.process(esc, conf.paths, conf.FB_PATH);
+  PathMonitor.process(esc, conf.paths || conf.FB_PATH);
   SearchQueue.init(esc, conf.FB_REQ, conf.FB_RES, conf.CLEANUP_INTERVAL);
 }

--- a/config.example.js
+++ b/config.example.js
@@ -57,8 +57,7 @@ else {
  *
  * To store your paths dynamically, rather than specifying them all here, you can store them in Firebase.
  * Format each path object with the same keys described above, and store the array of paths at whatever
- * location you specified in the FB_PATHS variable. Be sure to restrict that data in your Security Rules.
- ****************************************************/
+ * location you specified in the FB_PATH variable. Be sure to restrict that data in your Security Rules.  ****************************************************/
 exports.paths = [
   {
     path : "users",


### PR DESCRIPTION
The `PathMonitor.process` only accept two arguments. So I figured out that maybe what you want is that if the `conf.paths` is not set, then use the conf.FB_PATH.